### PR TITLE
Fix bug introduced by implementing switching spec/(lib)/ <-> lib/

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -222,27 +222,6 @@ second element."
         (setq mapping (cdr mapping))))
     target-filename))
 
-(defun ruby-test-find-target-filename (filename mapping)
-  "Find the target filename by matching FILENAME with the first
-element of each list in mapping, and replacing the match with the
-second element."
-  (let ((target-filename nil))
-    (while (and (not target-filename) mapping)
-      (let ((regexp-match (car (car mapping)))
-            (regexp-replace-candidates (cdr (car mapping))))
-        (if (string-match regexp-match filename)
-            (let ((target-filename-candidates
-                   (mapcar '(lambda (regexp)
-                              (replace-match regexp nil nil filename nil))
-                           regexp-replace-candidates)))
-              (setq target-filename
-                    (or (dolist (filename target-filename-candidates exist-filename)
-                          (when (file-exists-p filename)
-                            (setq exist-filename filename)))
-			(car target-filename-candidates)))))
-        (setq mapping (cdr mapping))))
-    target-filename))
-
 (defun ruby-test-find-testcase-at (file line)
   (save-excursion
     (set-buffer (get-file-buffer file))


### PR DESCRIPTION
I am sorry, but it looks like I've introduced a bug when implementing my changes. 

'dolist' tried to eval exist-filename which was just a symbol when no test files was found. This triggered error in Emacs.

I've fixed that issue and tested for a couple of days. It looks like everything works good now. Please merge this changes. 

Thank you for ruby-test-mode by the way! It is the best emacs package to work with ruby projects.
