### PR TITLE
Add shoulda to the find-testcase-at regexp

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -233,7 +233,7 @@ second element."
     (goto-line line)
     (end-of-line)
     (message "%s:%s" (current-buffer) (point))
-    (if (re-search-backward (concat "^[ \t]*\\(def\\|test\\|it\\)[ \t]+"
+    (if (re-search-backward (concat "^[ \t]*\\(def\\|test\\|it\\|should\\)[ \t]+"
                                     "\\([\"'].*?[\"']\\|" ruby-symbol-re "*\\)"
                                     "[ \t]*") nil t)
         (let ((name (match-string 2)))


### PR DESCRIPTION
This is a tiny change, but it lets me use ruby-test-find-testcase-at with shoulda

Thanks
