### PR TITLE
Sanitize the name so that shoulda tests with spaces are supported

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -246,7 +246,7 @@ second element."
        "\\?" "\\\\\\\\?"
        (replace-regexp-in-string
         "'_?\\|(_?\\|)_?" ".*"
-        (replace-regexp-in-string " +" "_" (match-string 1 name))))
+        (replace-regexp-in-string " +" "\\\\\\\\s+" (match-string 1 name))))
     (unless (string-equal "setup" name)
       name)))
 


### PR DESCRIPTION
This works for me with shoulda, but it might not be a good idea in other environments.  Any ideas?
