### PR TITLE
Use bundler for test-unit mode too.

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -286,7 +286,7 @@ depending on the filename."
 
 (defun ruby-test-test-command (filename &optional line-number)
   (let (command options name-options)
-    (setq command (or (ruby-test-ruby-executable) "ruby"))
+    (setq command (concat "bundle exec " (or (ruby-test-ruby-executable) "ruby")))
     (if (ruby-test-gem-root filename)
         (setq options (cons "-rubygems" options)))
     (setq options (cons "-I'lib:test'" options))


### PR DESCRIPTION
So I see that in `rspec` mode, we already [assume bundler usage](https://github.com/r0man/ruby-test-mode/blob/master/ruby-test-mode.el#L281).

I did the same thing for test-unit mode too. While this makes it work, I have a couple of questions:
- I see that we don't have tests for these command generating forms. I tried adding, but they use `file-name-directory` and `directory-file-name` - which check for the existence of these directories. So testing these commands is not easy - I tried this:

``` el
(ert-deftest  ruby-test-test-command ()
  (should (equal nil (ruby-test-test-command "other/exists_test.rb"))))
```

Do you see any alternatives (newb here, new to elisp and ert. So guidance will be valuable).
- It might be better for `ruby-test-test-command` and `ruby-test-spec-command` to return the command without the `bundle exec` prefix. Then, `ruby-test-command` (which calls these two forms) can use a var, say `ruby-test-command-prefix`, as the prefix. By default, we can have this var set to `bundle exec` and the user can turn it off, if they are not using bundler.

Do you think that's a valid use-case? If no one's going to use that, I'd rather keep it simple.
