### PR TITLE
testunit: ensure name-options is not nil

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -285,7 +285,8 @@ depending on the filename."
         (let ((test-case (ruby-test-find-testcase-at filename line-number)))
           (if test-case
               (setq name-options (format "--name /%s/" test-case))
-            (error "No test case at %s:%s" filename line-number))))
+            (error "No test case at %s:%s" filename line-number)))
+      (setq name-options ""))
     (format "%s %s %s %s" command (mapconcat 'identity options " ") filename name-options)))
 
 (defun ruby-test-project-root (filename root-predicate)


### PR DESCRIPTION
Previously if line-number was not present in a call to `ruby-test-test-command`,
the return result would include "nil" at the end of the command; e.g.,

```
bundle exec ruby -I'lib:test' /path/to/unit_test.rb nil
```

This would cause at least Rails tests to explode.
