### PR TITLE
A Project root can be defined by the presence of a test directory

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -250,7 +250,9 @@ as `ruby-test-run-file'"
         (message ruby-test-not-found-message)))))
 
 (defun ruby-test-run-command (command)
-  (setq default-directory (or (ruby-test-rails-root filename) (ruby-test-ruby-root filename)))
+  (setq default-directory (or (ruby-test-rails-root filename)
+                              (ruby-test-ruby-root filename)
+                              default-directory))
   (compilation-start command t))
 
 (defun ruby-test-command (filename &optional line-number)


### PR DESCRIPTION
This is useful for projects where a Rakefile is not present, as it provides an alternative means of detecting whether your project root is actually your project root.

I ran into this issue when working on a Goliath project which had none of the usual trappings of a Rakefile, Rails config files or a gemspec. Ruby test mode was causing Emacs to hang when running the specs unless I a) applied this patch, or b) touched an empty `Rakefile` in the root of the project.

I've built a test project that can be used to test this functionality. You can find it here:

https://github.com/eightbitraptor/ruby-test-mode-issue-example
