### PR TITLE
Interpolate line number with file name

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -280,7 +280,7 @@ depending on the filename."
       (setq command "bundle exec rspec"))
     (setq options ruby-test-rspec-options)
     (if line-number
-        (setq options (cons "--line" (cons (format "%d" line-number) options))))
+        (setq filename (format "%s:%s" filename line)))
     (format "%s %s %s" command (mapconcat 'identity options " ") filename)))
 
 (defun ruby-test-test-command (filename &optional line-number)


### PR DESCRIPTION
- --line does not work with rspec 3
- filename:line is supported in all versions
