### PR TITLE
Fixes bug finding target for unit test

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -108,8 +108,8 @@ match, the second the replace expression."
 
 (defcustom ruby-test-unit-filename-mapping
   '(
-    ("\\(.*\\)\\(app/\\)\\(controllers\\)\\(.*\\)\\([^/]*\\)\\(\\.rb\\)$" "\\1test/\\(controllers\\|functional\\)\\4_test\\5\\6")
-    ("\\(.*\\)\\(app/\\)\\(models\\)\\(.*\\)\\([^/]*\\)\\(\\.rb\\)$" "\\1test/\\(models\\|unit\\)\\4_test\\5\\6")
+    ("\\(.*\\)\\(app/\\)\\(controllers\\)\\(.*\\)\\([^/]*\\)\\(\\.rb\\)$" "\\1test/controllers\\4_test\\5\\6" "\\1test/functional\\4_test\\5\\6" )
+    ("\\(.*\\)\\(app/\\)\\(models\\)\\(.*\\)\\([^/]*\\)\\(\\.rb\\)$" "\\1test/models\\4_test\\5\\6" "\\1test/unit\\4_test\\5\\6")
     ("\\(.*\\)\\(lib/\\)\\(.*\\)\\([^/]*\\)\\(\\.rb\\)$" "\\1test/\\3\\4_test\\5" "\\1test/unit/\\3\\4_test\\5")
     ("\\(.*\\)\\(\\.rb\\)$" "\\1_test\\2"))
   "Regular expressions to map Ruby unit to implementation

--- a/tests/ruby-test-mode-tests.el
+++ b/tests/ruby-test-mode-tests.el
@@ -3,9 +3,9 @@
 (require 'ruby-test-mode)
 
 (ert-deftest ruby-test-unit-filename ()
-  (should (equal "test/functional/path/controller_test.rb" (ruby-test-unit-filename "app/controllers/path/controller.rb")))
+  (should (equal "test/controllers/path/controller_test.rb" (ruby-test-unit-filename "app/controllers/path/controller.rb")))
 
-  (should (equal "test/unit/path/model_test.rb" (ruby-test-unit-filename "app/models/path/model.rb")))
+  (should (equal "test/models/path/model_test.rb" (ruby-test-unit-filename "app/models/path/model.rb")))
 
   (should (equal "test/file_test.rb" (ruby-test-unit-filename "lib/file.rb")))
 


### PR DESCRIPTION
- Only the first element of the list ruby-test-unit-filename-mapping
  can be a regexp
