### PR TITLE
Use *-travis evm binaries, badge link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: emacs-lisp
 env:
-  - EVM_EMACS=emacs-26.1-bin
-  - EVM_EMACS=emacs-25.3-bin
-  - EVM_EMACS=emacs-24.5-bin
+  - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-24.5-travis
 install:
   - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
   - export PATH="$HOME/.evm/bin:$PATH"

--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 * ruby-test-mode.el
 
-  [[https://travis-ci.org/r0man/ruby-test-mode][https://travis-ci.org/ruby-test-mode/ruby-test-mode.svg]]
+  [[https://travis-ci.org/ruby-test-mode/ruby-test-mode][https://travis-ci.org/ruby-test-mode/ruby-test-mode.svg]]
   [[https://melpa.org/#/ruby-test-mode][https://melpa.org/packages/ruby-test-mode-badge.svg]]
 
   Emacs minor mode for Behaviour and Test Driven Development in Ruby.


### PR DESCRIPTION
Old emacs-*-bin images are not longer supported, using *-travis binaries instead.

@febeling I don't seem to have write access yet so keep creating PRs for now.