### PR TITLE
Support mapping {test,spec}/services to app/services

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -125,9 +125,9 @@ Test Driven Development in Ruby."
   `(
     (,(pcre-to-elisp "(.*)/spec/routing/routes_spec\\.rb$") "\\1/config/routes.rb")
     (,(pcre-to-elisp "(.*)/test/routing/routes_test\\.rb$") "\\1/config/routes.rb")
-    (,(pcre-to-elisp "(.*)/spec/(controllers|models|jobs|helpers|mailers|uploaders|api)/(.*)_spec\\.rb$")
+    (,(pcre-to-elisp "(.*)/spec/(controllers|models|jobs|helpers|mailers|uploaders|api|services)/(.*)_spec\\.rb$")
      "\\1/app/\\2/\\3.rb")
-    (,(pcre-to-elisp "(.*)/test/(controllers|models|jobs|helpers|mailers|uploaders|api)/(.*)_test\\.rb$")
+    (,(pcre-to-elisp "(.*)/test/(controllers|models|jobs|helpers|mailers|uploaders|api|services)/(.*)_test\\.rb$")
      "\\1/app/\\2/\\3.rb")
 
     (,(pcre-to-elisp "(.*)/spec/(views/.*)_spec\\.rb$") "\\1/app/\\2")

--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -124,7 +124,6 @@ Test Driven Development in Ruby."
 (defcustom ruby-test-implementation-filename-mapping
   `(
     (,(pcre-to-elisp "(.*)/spec/routing/routes_spec\\.rb$") "\\1/config/routes.rb")
-    (,(pcre-to-elisp "(.*)/spec/routing/routes_spec\\.rb$") "\\1/config/routes.rb")
     (,(pcre-to-elisp "(.*)/test/routing/routes_test\\.rb$") "\\1/config/routes.rb")
     (,(pcre-to-elisp "(.*)/spec/(controllers|models|jobs|helpers|mailers|uploaders|api)/(.*)_spec\\.rb$")
      "\\1/app/\\2/\\3.rb")

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -1,6 +1,8 @@
 (ert-deftest ruby-test-unit-filename ()
   (should (equal "project/test/controllers/path/controller_test.rb"
                  (ruby-test-unit-filename "project/app/controllers/path/controller.rb")))
+  (should (equal "project/test/services/path/service_test.rb"
+                 (ruby-test-unit-filename "project/app/services/path/service.rb")))
   (should (equal "project/test/models/path/model_test.rb"
                  (ruby-test-unit-filename "project/app/models/path/model.rb")))
   (should (equal "project/test/file_test.rb"
@@ -38,6 +40,8 @@
                  (ruby-test-specification-filename "project/app/models/file.rb")))
   (should (equal "project/spec/controllers/file_spec.rb"
                  (ruby-test-specification-filename "project/app/controllers/file.rb")))
+  (should (equal "project/spec/services/file_spec.rb"
+                 (ruby-test-specification-filename "project/app/services/file.rb")))
   (should (equal "project/spec/helpers/file_spec.rb"
                  (ruby-test-specification-filename "project/app/helpers/file.rb")))
   (should (equal "project/spec/views/posts/new.html.erb_spec.rb"
@@ -64,6 +68,8 @@
                  (ruby-test-implementation-filename "project/spec/helpers/file_spec.rb")))
   (should (equal "project/app/views/posts/new.html.erb"
                  (ruby-test-implementation-filename "project/spec/views/posts/new.html.erb_spec.rb")))
+  (should (equal "project/app/services/some_service/file.rb"
+                 (ruby-test-implementation-filename "project/spec/services/some_service/file_spec.rb")))
   (should (equal "project/lib/something/file.rb"
                  (ruby-test-implementation-filename "project/spec/something/file_spec.rb")))
   (should (equal "project/lib/some_lib/file.rb"

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -53,6 +53,26 @@
   (should (equal "project/spec/javascripts/file_spec.coffee"
                  (ruby-test-specification-filename "project/app/assets/javascripts/file.coffee"))))
 
+(ert-deftest ruby-test-implementation-filename ()
+  (should (equal "project/app/models/file.rb"
+                 (ruby-test-implementation-filename "project/spec/models/file_spec.rb")))
+  (should (equal "project/app/controllers/file.rb"
+                 (ruby-test-implementation-filename "project/spec/controllers/file_spec.rb")))
+  (should (equal "project/app/services/file.rb"
+                 (ruby-test-implementation-filename "project/spec/services/file_spec.rb")))
+  (should (equal "project/app/helpers/file.rb"
+                 (ruby-test-implementation-filename "project/spec/helpers/file_spec.rb")))
+  (should (equal "project/app/views/posts/new.html.erb"
+                 (ruby-test-implementation-filename "project/spec/views/posts/new.html.erb_spec.rb")))
+  (should (equal "project/lib/something/file.rb"
+                 (ruby-test-implementation-filename "project/spec/something/file_spec.rb")))
+  (should (equal "project/lib/some_lib/file.rb"
+                 (ruby-test-implementation-filename "project/spec/some_lib/file_spec.rb")))
+  (should (equal "project/something/file.rb"
+                 (ruby-test-implementation-filename "project/something/file_spec.rb")))
+  (should (equal "project/app/assets/javascripts/file.coffee"
+                 (ruby-test-implementation-filename "project/spec/javascripts/file_spec.coffee"))))
+
 (ert-deftest ruby-test-testcase-name-test ()
   (find-file "test/unit_test.rb")
   (should (equal "test_one"


### PR DESCRIPTION
I work on a project that uses the Services pattern (see e.g. https://www.toptal.com/ruby-on-rails/rails-service-objects-tutorial). We put service object implementation files in `app/services` and test files in `test/services`, but unfortunately the existing ruby-test-mode mappings do not allow for finding the implementation from the test.