### PR TITLE
Improve execution environment handling

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -91,6 +91,13 @@ Test Driven Development in Ruby."
   :type '(list)
   :group 'ruby-test)
 
+(defcustom ruby-test-execution-environment
+  '("PAGER=cat")
+  "Environment variables to be set when running tests."
+  :initialize 'custom-initialize-default
+  :type '(repeat (string :tag "ENVVARNAME=VALUE"))
+  :group 'ruby-test)
+
 (defvar ruby-test-default-library
   "test"
   "Define the default test library.")
@@ -419,7 +426,9 @@ When no tests had been run before calling this function, do nothing."
 (defun ruby-test-run-command (command)
   "Run compilation COMMAND in rails or ruby root directory."
   (setq ruby-test-last-test-command command)
-  (compilation-start command t))
+  (let ((compilation-environment
+         (append ruby-test-execution-environment compilation-environment)))
+    (compilation-start command t)))
 
 (defun ruby-test-command (filename &optional line-number)
   "Return the command to run a unit test or a specification depending on the FILENAME and LINE-NUMBER."
@@ -441,7 +450,7 @@ When no tests had been run before calling this function, do nothing."
         (extra-options (if (not (null ruby-test-rails-test-options))
                            (mapconcat 'identity ruby-test-rails-test-options " ")
                          "")))
-    (format "PAGER=cat bundle exec rails test %s %s%s" extra-options filename line-part)))
+    (format "bundle exec rails test %s %s%s" extra-options filename line-part)))
 
 (defun ruby-test-minitest-command (filename &optional line-number)
   "Return command to run minitest in FILENAME at LINE-NUMBER."

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -84,7 +84,7 @@
     (should (string-match "bundle exec ruby -I'lib:test' -rrubygems ./test/unit_test.rb"
               (ruby-test-command "./test/unit_test.rb"))))
   (with-test-file "config/environment.rb"
-    (should (string-match "PAGER=cat bundle exec rails test -v ./test/unit_test.rb"
+    (should (string-match "bundle exec rails test -v ./test/unit_test.rb"
               (ruby-test-command "./test/unit_test.rb"))))
   (should (string-match "bundle exec rspec -b ./spec/unit_spec.rb"
             (ruby-test-spec-command "./spec/unit_spec.rb"))))


### PR DESCRIPTION
In #59 I introduced the Ruby on Rails test runner invocation with `PAGER=cat` on the front. This was because when using an interactive `pry` session in a test, you can get annoying warnings like

```
WARNING: terminal is not fully functional
-  (press RETURN)
```

when invoking `pry` functions that output a lot of text. This is because it tries to use `less` or whatever by default.

I realized that

1. Though I haven't seen this issue with other test runners, they could have the same problem in some configurations
2. Setting the envar by prepending to the command string is a bit hacky and presumes execution in a shell (maybe that causes a problem on Windows or something?)
3. People might want to override that or set their own envars

So I broke that out into a `defcustom` and set it to take effect by the proper `compile.el` mechanism.