### PR TITLE
Replace obsolete cl package, flet macro

### DIFF
--- a/TODOs.org
+++ b/TODOs.org
@@ -2,4 +2,3 @@
   - integration tests for interactive functions
   - improve "with-test-file" helper method
   - figure out "wrong stringp nil type" issue, gem root and .gemspec file
-  - update obsolete flet library

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -13,10 +13,10 @@
                     "third/\\1_test.rb"))))
     (should (equal "exists_test.rb"
                    (ruby-test-find-target-filename "exists.rb" mapping)))
-    (flet ((file-exists-p (filename)
-                          (if (string-match "other" filename)
-                              t
-                            nil)))
+    (cl-letf (((symbol-function 'file-exists-p) (lambda (filename)
+                                                  (if (string-match "other" filename)
+                                                      t
+                                                    nil))))
       (should (equal "other/exists_test.rb"
                      (ruby-test-find-target-filename "exists.rb" mapping))))))
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -4,7 +4,7 @@
 (require 'testcover)
 (require 'f)
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 (require 'ert)
 
 (require 'ruby-test-mode)


### PR DESCRIPTION
I got the hint for properly replacing `flet` (with dynamic binding) from this blog post:
https://endlessparentheses.com/understanding-letf-and-how-it-replaces-flet.html