### PR TITLE
Check for MiniTest, RSpec before Rails when determining test command

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -431,12 +431,12 @@ When no tests had been run before calling this function, do nothing."
 
 (defun ruby-test-command (filename &optional line-number)
   "Return the command to run a unit test or a specification depending on the FILENAME and LINE-NUMBER."
-  (cond ((ruby-test-rails-p filename)
-         (ruby-test-rails-command filename line-number))
-        ((ruby-test-minitest-p filename)
+  (cond ((ruby-test-minitest-p filename)
          (ruby-test-minitest-command filename line-number))
         ((ruby-test-spec-p filename)
          (ruby-test-spec-command filename line-number))
+        ((ruby-test-rails-p filename)
+         (ruby-test-rails-command filename line-number))
         ((ruby-test-p filename)
          (ruby-test-test-command filename line-number))
         (t (message "File is not a known ruby test file"))))

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -112,6 +112,9 @@
   (with-test-file "config/environment.rb"
     (should (string-match "bundle exec rails test -v ./test/unit_test.rb"
               (ruby-test-command "./test/unit_test.rb"))))
+  (with-test-file "config/environment.rb"
+    (should (string-match "bundle exec rspec -b ./spec/unit_spec.rb"
+              (ruby-test-command "./spec/unit_spec.rb"))))
   (should (string-match "bundle exec rspec -b ./spec/unit_spec.rb"
             (ruby-test-spec-command "./spec/unit_spec.rb"))))
 


### PR DESCRIPTION
It seems the Rails test runner isn't smart enough to run RSpec tests. Moving the check for Rails to come *after* the checks for RSpec and MiniTest should solve this acceptably.